### PR TITLE
feat: simple pixel-based `border-radius`

### DIFF
--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -15,14 +15,23 @@ pub struct Instance {
     pos: [f32; 2],
     size: [f32; 2],
     background_color: [f32; 4],
+    border_radius: f32,
 }
 
 impl Instance {
-    pub fn new(x: f32, y: f32, width: f32, height: f32, background_color: [f32; 4]) -> Self {
+    pub fn new(
+        x: f32,
+        y: f32,
+        width: f32,
+        height: f32,
+        background_color: [f32; 4],
+        border_radius: f32,
+    ) -> Self {
         Self {
             pos: [x, y],
             size: [width, height],
             background_color,
+            border_radius,
         }
     }
 }
@@ -182,6 +191,11 @@ impl<'window> Gpu<'window> {
                             offset: std::mem::size_of::<[f32; 4]>() as wgpu::BufferAddress,
                             shader_location: 2,
                             format: wgpu::VertexFormat::Float32x4,
+                        },
+                        wgpu::VertexAttribute {
+                            offset: std::mem::size_of::<[f32; 8]>() as wgpu::BufferAddress,
+                            shader_location: 3,
+                            format: wgpu::VertexFormat::Float32,
                         },
                     ],
                 }],

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -20,6 +20,7 @@ pub struct Node {
     kind: NodeKind,
     style: Style,
     background_color: [f32; 4],
+    border_radius: f32,
     cache: Cache,
     pub layout: Layout,
     pub children: Vec<NodeId>,
@@ -31,6 +32,7 @@ impl Default for Node {
             kind: NodeKind::Flexbox,
             style: Style::default(),
             background_color: [0.0, 0.0, 0.0, 0.0],
+            border_radius: 0.0,
             cache: Cache::new(),
             layout: Layout::with_order(0),
             children: Vec::new(),
@@ -80,7 +82,12 @@ impl Gui {
         }
     }
 
-    pub fn create_node(&mut self, style: Style, background_color: [f32; 4]) -> NodeId {
+    pub fn create_node(
+        &mut self,
+        style: Style,
+        background_color: [f32; 4],
+        border_radius: u32,
+    ) -> NodeId {
         // todo block layout
         let kind = if style.display == Display::Grid {
             NodeKind::Grid
@@ -91,6 +98,7 @@ impl Gui {
         let node = Node {
             style,
             background_color,
+            border_radius: border_radius as f32,
             kind,
             ..Node::default()
         };
@@ -168,6 +176,7 @@ impl Gui {
                 node.layout.size.width,
                 node.layout.size.height,
                 node.background_color,
+                node.border_radius,
             );
 
             instances.push(instance);

--- a/src/javascript_runtime/mod.rs
+++ b/src/javascript_runtime/mod.rs
@@ -27,10 +27,12 @@ use crate::gui::Gui;
 #[op2]
 #[bigint]
 #[string]
+#[number]
 fn op_create_instance(
     state: &mut OpState,
     #[serde] layout: Style,
     #[string] background_color: String,
+    border_radius: u32,
 ) -> Result<usize, JsErrorBox> {
     let default_background: &str = "transparent";
 
@@ -42,7 +44,7 @@ fn op_create_instance(
         .borrow::<Arc<Mutex<Gui>>>()
         .lock()
         .unwrap()
-        .create_node(layout, parsed_background_color);
+        .create_node(layout, parsed_background_color, border_radius);
 
     Ok(usize::from(node_id))
 }

--- a/src/javascript_runtime/reconciler.ts
+++ b/src/javascript_runtime/reconciler.ts
@@ -60,8 +60,8 @@ export const reconciler = ReactReconciler<
 
   createInstance(_type, props, _rootContainerInstance, _hostContext, _internalInstanceHandle) {
     const taffyStyle = taffyFromCss(props.style as Record<string, unknown>);
-    const { backgroundColor } = props.style;
-    const id = create_instance(taffyStyle, backgroundColor);
+    const { backgroundColor = "transparent", borderRadius = 0 } = props.style;
+    const id = create_instance(taffyStyle, backgroundColor, borderRadius);
     return { type: "div", id };
   },
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,8 +12,8 @@ ReactWGPU.render(
       gap: "10%",
     }}
   >
-    <div style={{ width: "500px", height: "500px", backgroundColor: "#f00" }}></div>
-    <div style={{ width: "500px", height: "500px", backgroundColor: "#0f0" }}></div>
-    <div style={{ width: "500px", height: "500px", backgroundColor: "#00f" }}></div>
+    <div style={{ width: "500px", height: "500px", backgroundColor: "#f00", borderRadius: 20 }}></div>
+    <div style={{ width: "500px", height: "500px", backgroundColor: "#0f0", borderRadius: 5 }}></div>
+    <div style={{ width: "500px", height: "500px", backgroundColor: "#00f", borderRadius: 999 }}></div>
   </div>
 );

--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -3,6 +3,9 @@ var<push_constant> viewport: vec2<f32>;
 struct VertexOutput {
     @builtin(position) clip_position: vec4<f32>,
     @location(0) background_color: vec4<f32>,
+    @location(1) border_radius: f32,
+    @location(2) rect_pos: vec2<f32>,
+    @location(3) rect_size: vec2<f32>,
 };
 
 @vertex
@@ -11,6 +14,7 @@ fn vs_main(
     @location(0) instance_pos: vec2<f32>,
     @location(1) instance_size: vec2<f32>,
     @location(2) background_color: vec4<f32>,
+    // @location(3) border_radius: f32,
 ) -> VertexOutput {
 
     var vertex_pos: vec2<f32>;
@@ -31,11 +35,28 @@ fn vs_main(
 
     output.clip_position = vec4<f32>(ndc_x, ndc_y, 1.0, 1.0);
     output.background_color = background_color;
+    output.border_radius = 20.0;  // example value of 10px for border radius, will be parameterized later
+    output.rect_pos = vertex_pos * instance_size;
+    output.rect_size = instance_size;
 
     return output;
 }
 
 @fragment 
 fn fs_main(vs_output: VertexOutput) -> @location(0) vec4f {
-    return vs_output.background_color;
+    let radius = vs_output.border_radius;
+    let rect_size = vs_output.rect_size;
+    let rect_pos = vs_output.rect_pos;
+    
+    // Calculate distance from corners for rounded rectangle
+    let corner_radius = min(radius, min(rect_size.x, rect_size.y) * 0.5);
+    
+    // Calculate the distance to the nearest corner
+    let corner_distance = length(max(abs(rect_pos - rect_size * 0.5) - (rect_size * 0.5 - corner_radius), vec2<f32>(0.0, 0.0)));
+    
+    // Anti-aliased edge
+    let edge_softness = 1.0;
+    let alpha = 1.0 - smoothstep(corner_radius - edge_softness, corner_radius, corner_distance);
+    
+    return vec4<f32>(vs_output.background_color.rgb, vs_output.background_color.a * alpha);
 }

--- a/src/shader.wgsl
+++ b/src/shader.wgsl
@@ -14,7 +14,7 @@ fn vs_main(
     @location(0) instance_pos: vec2<f32>,
     @location(1) instance_size: vec2<f32>,
     @location(2) background_color: vec4<f32>,
-    // @location(3) border_radius: f32,
+    @location(3) border_radius: f32,
 ) -> VertexOutput {
 
     var vertex_pos: vec2<f32>;
@@ -35,7 +35,7 @@ fn vs_main(
 
     output.clip_position = vec4<f32>(ndc_x, ndc_y, 1.0, 1.0);
     output.background_color = background_color;
-    output.border_radius = 20.0;  // example value of 10px for border radius, will be parameterized later
+    output.border_radius = border_radius;
     output.rect_pos = vertex_pos * instance_size;
     output.rect_size = instance_size;
 


### PR DESCRIPTION
 - pixel values (absolute numbers) only
 - default value handling done in js not in rust